### PR TITLE
fix(if)no longer allow on template

### DIFF
--- a/src/walk.js
+++ b/src/walk.js
@@ -19,6 +19,8 @@ export const _directives = {
   text: textDirective
 };
 
+const walkCache = new WeakMap();
+
 export default function walk(reactiveNode, scope, rootNode) {
   const walker = document.createNodeIterator(
     rootNode,
@@ -26,11 +28,18 @@ export default function walk(reactiveNode, scope, rootNode) {
   );
   let node;
 
+  // node iterator is a live list meaning that any new elements
+  // added to the DOM during traversal will also get processed
   while ((node = walker.nextNode())) {
+    if (walkCache.has(node)) {
+      continue;
+    }
+    walkCache.set(node, 1);
+
     switch (node.nodeType) {
       case 1: {
         // Node.ELEMENT_NODE
-        let hasForBinding = node.hasAttribute(':for');
+        const hasForBinding = node.hasAttribute(':for');
         for (let { name, value } of [...node.attributes]) {
           const type = name[0];
 

--- a/test/directives/if.spec.js
+++ b/test/directives/if.spec.js
@@ -68,16 +68,6 @@ describe('if directive', () => {
       host.state.value = true;
       assert.exists(host.querySelector('#target'));
     });
-
-    it('when :if is used on template', () => {
-      const { target } = setupFixture(
-        `<template :if="true">
-          <span>Hello</span>
-          <span id="target">World</span>
-        </template>`
-      );
-      assert.isTrue(target.isConnected);
-    });
   });
 
   describe('hides the element', () => {
@@ -166,18 +156,6 @@ describe('if directive', () => {
       host.state.value = false;
       assert.notExists(host.querySelector('#target'));
     });
-
-    it('when :if is used on template', () => {
-      const { host } = setupFixture(
-        `<template :if="false">
-          <span>Hello</span>
-          <span id="target">World</span>
-        </template>`,
-        {},
-        false
-      );
-      assert.notExists(host.querySelector('#target'));
-    });
   });
 
   describe('when the binding changes', () => {
@@ -223,6 +201,186 @@ describe('if directive', () => {
       assert.isTrue(host.children[1] === host.querySelector('#b'));
       assert.isTrue(host.children[2] === host.querySelector('#c'));
       assert.isTrue(host.children[3] === host.querySelector('#d'));
+    });
+
+    it('works when setting to the same value twice', () => {
+      const { host } = setupFixture(
+        `<div id="target" :if="state.value">hello</div>`,
+        {
+          state: {
+            value: false
+          }
+        },
+        false
+      );
+      host.state.value = true;
+      host.state.value = true;
+      host.state.value = true;
+      host.state.value = true;
+      host.state.value = false;
+      host.state.value = false;
+      host.state.value = true;
+      host.state.value = true;
+      host.state.value = false;
+      host.state.value = false;
+      host.state.value = false;
+      host.state.value = true;
+      assert.exists(host.querySelector('#target'));
+    });
+  });
+
+  describe('nested if', () => {
+    it('processes bindings inside :if', () => {
+      const { target } = setupFixture(
+        `<span :if="true">
+          <span>Hello</span>
+          <span id="target" :foo="state.foo">{{ state.value }}</span>
+        </span>`,
+        {
+          state: {
+            foo: 'bar',
+            value: 'hello'
+          }
+        }
+      );
+      assert.equal(target.getAttribute('foo'), 'bar');
+      assert.equal(target.textContent, 'hello');
+    });
+
+    it('processes bindings inside :if even when not shown at first', () => {
+      const { host } = setupFixture(
+        `<span :if="state.if">
+          <span>Hello</span>
+          <span id="target" :foo="state.foo">{{ state.value }}</span>
+        </span>`,
+        {
+          state: {
+            if: false,
+            foo: 'bar',
+            value: 'hello'
+          }
+        },
+        false
+      );
+      host.state.if = true;
+      const target = host.querySelector('#target');
+      assert.equal(target.getAttribute('foo'), 'bar');
+      assert.equal(target.textContent, 'hello');
+    });
+
+    it('processes nested :if nodes', () => {
+      const { target } = setupFixture(
+        `<span :if="true">
+          <span>Hello</span>
+          <span :if="true">
+            <span id="target" :foo="state.foo">{{ state.value }}</span>
+          </span>
+        </span>`,
+        {
+          state: {
+            foo: 'bar',
+            value: 'hello'
+          }
+        }
+      );
+      assert.equal(target.getAttribute('foo'), 'bar');
+      assert.equal(target.textContent, 'hello');
+    });
+
+    it('processes nested :if nodes when inner is not shown first', () => {
+      const { host } = setupFixture(
+        `<span :if="true">
+          <span>Hello</span>
+          <span :if="state.if">
+            <span id="target" :foo="state.foo">{{ state.value }}</span>
+          </span>
+        </span>`,
+        {
+          state: {
+            if: false,
+            foo: 'bar',
+            value: 'hello'
+          }
+        },
+        false
+      );
+      host.state.if = true;
+      const target = host.querySelector('#target');
+      assert.equal(target.getAttribute('foo'), 'bar');
+      assert.equal(target.textContent, 'hello');
+    });
+
+    it('processes nested :if nodes when outer is not shown first', () => {
+      const { host } = setupFixture(
+        `<span :if="state.if">
+          <span>Hello</span>
+          <span :if="true">
+            <span id="target" :foo="state.foo">{{ state.value }}</span>
+          </span>
+        </span>`,
+        {
+          state: {
+            if: false,
+            foo: 'bar',
+            value: 'hello'
+          }
+        },
+        false
+      );
+      host.state.if = true;
+      const target = host.querySelector('#target');
+      assert.equal(target.getAttribute('foo'), 'bar');
+      assert.equal(target.textContent, 'hello');
+    });
+
+    it('processes nested :if nodes when both are not shown first (in order)', () => {
+      const { host } = setupFixture(
+        `<span :if="state.if">
+          <span>Hello</span>
+          <span :if="state.if2">
+            <span id="target" :foo="state.foo">{{ state.value }}</span>
+          </span>
+        </span>`,
+        {
+          state: {
+            if: false,
+            if2: false,
+            foo: 'bar',
+            value: 'hello'
+          }
+        },
+        false
+      );
+      host.state.if = true;
+      host.state.if2 = true;
+      const target = host.querySelector('#target');
+      assert.equal(target.getAttribute('foo'), 'bar');
+      assert.equal(target.textContent, 'hello');
+    });
+
+    it('processes nested :if nodes when both are not shown first (reverse order)', () => {
+      const { host } = setupFixture(
+        `<span :if="state.if">
+          <span>Hello</span>
+          <span :if="state.if2">
+            <span id="target" :foo="state.foo">{{ state.value }}</span>
+          </span>
+        </span>`,
+        {
+          state: {
+            if: false,
+            if2: false,
+            foo: 'bar',
+            value: 'hello'
+          }
+        },
+        false
+      );
+      host.state.if2 = true;
+      host.state.if = true;
+      const target = host.querySelector('#target');
+      assert.equal(target.getAttribute('foo'), 'bar');
+      assert.equal(target.textContent, 'hello');
     });
   });
 });

--- a/test/walk.spec.js
+++ b/test/walk.spec.js
@@ -222,4 +222,15 @@ describe('walk', () => {
       spy.calledWith(fixture, scope, target, 'item', 'state.foo')
     );
   });
+
+  it('does not process nodes twice', () => {
+    fixture.innerHTML = '<div id="target" :item="state.foo"></div>';
+    const scope = { state: { foo: 'bar' } };
+    const target = fixture.querySelector('#target');
+    walk(fixture, scope, fixture);
+    const spy = sinon.spy(_directives, 'bind');
+    target.setAttribute(':thing', 'state.foo');
+    walk(fixture, scope, fixture);
+    assert.isFalse(spy.called);
+  });
 });


### PR DESCRIPTION
Adds a lot of code and is hard to process when templates are nested inside templates. Also switch to holding the place of the if node with an empty text node instead of outright removing it from the DOM.